### PR TITLE
Add configurable IAM policy for mail user

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,14 @@ For a complete example, see [examples/complete](examples/complete).
 
 For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest) (which tests and deploys the example on AWS), see [test](test).
 
-What's worth to note is that every AWS SES starts in Sandbox. Sending emals via it (emails not verified in AWS SES) is only allowed after support request.
+What's worth to note is that every AWS SES starts in Sandbox. Sending emails via it (emails not verified in AWS SES) is only allowed after support request.
 
 SES is avaialable in regions:
 - us-east-1
 - us-west-2
 - ap-south-1
 - ap-southeast-2
+- eu-west-1
 - eu-west-2
 - sa-east-1
 
@@ -120,31 +121,47 @@ Available targets:
   lint                                Lint terraform code
 
 ```
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| null | ~> 2.0 |
+| template | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| attributes | Additional attributes (_e.g._ "1") | list(string) | `<list>` | no |
-| delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
-| domain | The domain to create the SES identity for. | string | - | yes |
-| enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
-| name | Name of the application | string | - | yes |
-| namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
-| stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
-| tags | Additional tags (_e.g._ { BusinessUnit : ABC }) | map(string) | `<map>` | no |
-| verify_dkim | If provided the module will create Route53 DNS records used for DKIM verification. | bool | `false` | no |
-| verify_domain | If provided the module will create Route53 DNS records used for domain verification. | bool | `false` | no |
-| zone_id | Route53 parent zone ID. If provided (not empty), the module will create Route53 DNS records used for verification | string | `` | no |
+|------|-------------|------|---------|:--------:|
+| attributes | Additional attributes (\_e.g.\_ "1") | `list(string)` | `[]` | no |
+| delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| domain | The domain to create the SES identity for. | `string` | n/a | yes |
+| enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
+| iam\_permissions | Specifies permissions for the IAM user. | `list(string)` | <pre>[<br>  "ses:SendRawEmail"<br>]</pre> | no |
+| name | Name of the application | `string` | n/a | yes |
+| namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
+| stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
+| tags | Additional tags (\_e.g.\_ { BusinessUnit : ABC }) | `map(string)` | `{}` | no |
+| verify\_dkim | If provided the module will create Route53 DNS records used for DKIM verification. | `bool` | `false` | no |
+| verify\_domain | If provided the module will create Route53 DNS records used for domain verification. | `bool` | `false` | no |
+| zone\_id | Route53 parent zone ID. If provided (not empty), the module will create Route53 DNS records used for verification | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| smtp_password | The SMTP password. This will be written to the state file in plain text. |
-| smtp_user | The SMTP user which is access key ID. |
-| user_arn | The ARN assigned by AWS for this user. |
-| user_name | Normalized IAM user name. |
-| user_unique_id | The unique ID assigned by AWS. |
+| smtp\_password | The SMTP password. This will be written to the state file in plain text. |
+| smtp\_user | The SMTP user which is access key ID. |
+| user\_arn | The ARN assigned by AWS for this user. |
+| user\_name | Normalized IAM user name. |
+| user\_unique\_id | The unique ID assigned by AWS. |
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -53,13 +53,14 @@ usage: |-
 
   For automated tests of the complete example using [bats](https://github.com/bats-core/bats-core) and [Terratest](https://github.com/gruntwork-io/terratest) (which tests and deploys the example on AWS), see [test](test).
 
-  What's worth to note is that every AWS SES starts in Sandbox. Sending emals via it (emails not verified in AWS SES) is only allowed after support request.
+  What's worth to note is that every AWS SES starts in Sandbox. Sending emails via it (emails not verified in AWS SES) is only allowed after support request.
 
   SES is avaialable in regions:
   - us-east-1
   - us-west-2
   - ap-south-1
   - ap-southeast-2
+  - eu-west-1
   - eu-west-2
   - sa-east-1
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,26 +1,42 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 0.12.0 |
+| aws | ~> 2.0 |
+| null | ~> 2.0 |
+| template | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | ~> 2.0 |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| attributes | Additional attributes (_e.g._ "1") | list(string) | `<list>` | no |
-| delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
-| domain | The domain to create the SES identity for. | string | - | yes |
-| enabled | Set to false to prevent the module from creating any resources | bool | `true` | no |
-| name | Name of the application | string | - | yes |
-| namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
-| stage | Stage (e.g. `prod`, `dev`, `staging`) | string | `` | no |
-| tags | Additional tags (_e.g._ { BusinessUnit : ABC }) | map(string) | `<map>` | no |
-| verify_dkim | If provided the module will create Route53 DNS records used for DKIM verification. | bool | `false` | no |
-| verify_domain | If provided the module will create Route53 DNS records used for domain verification. | bool | `false` | no |
-| zone_id | Route53 parent zone ID. If provided (not empty), the module will create Route53 DNS records used for verification | string | `` | no |
+|------|-------------|------|---------|:--------:|
+| attributes | Additional attributes (\_e.g.\_ "1") | `list(string)` | `[]` | no |
+| delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` | `string` | `"-"` | no |
+| domain | The domain to create the SES identity for. | `string` | n/a | yes |
+| enabled | Set to false to prevent the module from creating any resources | `bool` | `true` | no |
+| iam\_permissions | Specifies permissions for the IAM user. | `list(string)` | <pre>[<br>  "ses:SendRawEmail"<br>]</pre> | no |
+| name | Name of the application | `string` | n/a | yes |
+| namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
+| stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
+| tags | Additional tags (\_e.g.\_ { BusinessUnit : ABC }) | `map(string)` | `{}` | no |
+| verify\_dkim | If provided the module will create Route53 DNS records used for DKIM verification. | `bool` | `false` | no |
+| verify\_domain | If provided the module will create Route53 DNS records used for domain verification. | `bool` | `false` | no |
+| zone\_id | Route53 parent zone ID. If provided (not empty), the module will create Route53 DNS records used for verification | `string` | `""` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| smtp_password | The SMTP password. This will be written to the state file in plain text. |
-| smtp_user | The SMTP user which is access key ID. |
-| user_arn | The ARN assigned by AWS for this user. |
-| user_name | Normalized IAM user name. |
-| user_unique_id | The unique ID assigned by AWS. |
+| smtp\_password | The SMTP password. This will be written to the state file in plain text. |
+| smtp\_user | The SMTP user which is access key ID. |
+| user\_arn | The ARN assigned by AWS for this user. |
+| user\_name | Normalized IAM user name. |
+| user\_unique\_id | The unique ID assigned by AWS. |
 

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ data "aws_iam_policy_document" "ses_user_policy" {
   count = var.enabled ? 1 : 0
 
   statement {
-    actions   = ["ses:SendRawEmail"]
+    actions   = var.iam_permissions
     resources = [join("", aws_ses_domain_identity.ses_domain.*.arn)]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -62,3 +62,8 @@ variable "verify_dkim" {
   default     = false
 }
 
+variable "iam_permissions" {
+  type        = list(string)
+  description = "Specifies permissions for the IAM user."
+  default     = ["ses:SendRawEmail"]
+}


### PR DESCRIPTION
## what
* Added an optional variable to configure the IAM Policy for the user. 

## why
* Out of the box it only configures the user with `ses:SendRawEmail` permission but it might be desirable to use `ses:SendEmail` too / instead.

## references
* n/a

## remarks
* The docs have changed significantly even though I only added one variable and made a few minor changes. I asked about this on [Slack](https://sweetops.slack.com/archives/CB6GHNLG0/p1592311234210200) and this is due to the fact that a new `terraform-docs` is being used. 