### PR TITLE
Add IAM secret output for usage with SES API

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Available targets:
 | smtp\_user | The SMTP user which is access key ID. |
 | user\_arn | The ARN assigned by AWS for this user. |
 | user\_name | Normalized IAM user name. |
+| user\_secret | The IAM secret for usage with SES API. This will be written to the state file in plain text. |
 | user\_unique\_id | The unique ID assigned by AWS. |
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -38,5 +38,6 @@
 | smtp\_user | The SMTP user which is access key ID. |
 | user\_arn | The ARN assigned by AWS for this user. |
 | user\_name | Normalized IAM user name. |
+| user\_secret | The IAM secret for usage with SES API. This will be written to the state file in plain text. |
 | user\_unique\_id | The unique ID assigned by AWS. |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,12 @@ output "user_unique_id" {
   description = "The unique ID assigned by AWS."
 }
 
+output "user_secret" {
+  sensitive   = true
+  value       = module.ses_user.secret
+  description = "The IAM secret for usage with SES API. This will be written to the state file in plain text."
+}
+
 # https://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-credentials.html
 output "smtp_password" {
   sensitive   = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,7 +15,7 @@ output "user_unique_id" {
 
 output "user_secret" {
   sensitive   = true
-  value       = module.ses_user.secret
+  value       = module.ses_user.secret_access_key
   description = "The IAM secret for usage with SES API. This will be written to the state file in plain text."
 }
 


### PR DESCRIPTION
## what
* Adds a `user_secret` output which contains the IAM Secret 

## why
* This allows that the IAM User can (also) be used through the SES API and not just via SMTP

## references

