### PR TITLE
Added support for Cloudflare

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -36,7 +36,7 @@ description: |-
 # How to use this project
 usage: |-
   This module creates a SES domain with IAM user that is able to send emails with it.
-  If module is provided with Route53 Zone ID it can also create verification DNS records for domain and DKIM.
+  If module is provided with Route53 Zone ID or Cloudfront Zone ID it can also create verification DNS records for domain and DKIM.
 
   For a complete example, see [examples/complete](examples/complete).
 

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "label" {
 }
 
 /*
-Create SES domain identity and verify it with Route53 DNS records
+Create SES domain identity and verify it with Cloudflare DNS records
 */
 
 resource "aws_ses_domain_identity" "ses_domain" {

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,16 @@ resource "cloudflare_record" "amazonses_verification_record" {
   type    = "TXT"
   ttl     = "600"
 }
+  
+resource "dnsimple_record" "amazonses_verification_record" {
+  count = var.enabled && var.verify_dnsimple_domain ? 1 : 0
+  
+  domain  = var.domain
+  name    = "_amazonses.${var.domain}"
+  value   = aws_ses_domain_identity.ses_domain.0.verification_token
+  type    = "TXT"
+  ttl     = "600"
+}
 
 resource "aws_ses_domain_dkim" "ses_domain_dkim" {
   count = var.enabled ? 1 : 0
@@ -60,6 +70,20 @@ resource "cloudflare_record" "amazonses_dkim_record" {
   count = var.enabled && var.verify_cloudflare_dkim ? 3 : 0
 
   zone_id = var.zone_id
+  name = format(
+    "%s._domainkey.%s",
+    element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index),
+    var.domain,
+  )
+  type    = "CNAME"
+  ttl     = "600"
+  value   = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"
+}
+  
+resource "dnsimple_record" "amazonses_dkim_record" {
+  count = var.enabled && var.verify_dnsimple_dkim ? 3 : 0
+
+  domain = var.domain
   name = format(
     "%s._domainkey.%s",
     element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index),

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "dnsimple_record" "amazonses_verification_record" {
   count = var.enabled && var.verify_dnsimple_domain ? 1 : 0
   
   domain  = var.domain
-  name    = "_amazonses.${var.domain}"
+  name    = "_amazonses"
   value   = aws_ses_domain_identity.ses_domain.0.verification_token
   type    = "TXT"
   ttl     = "60"

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "label" {
 }
 
 /*
-Create SES domain identity and verify it with Cloudflare DNS records
+Create SES domain identity and verify it with Route 53 or Cloudflare DNS records
 */
 
 resource "aws_ses_domain_identity" "ses_domain" {

--- a/main.tf
+++ b/main.tf
@@ -20,14 +20,23 @@ resource "aws_ses_domain_identity" "ses_domain" {
   domain = var.domain
 }
 
-resource "aws_route53_record" "amazonses_verification_record" {
-  count = var.enabled && var.verify_domain ? 1 : 0
+#resource "aws_route53_record" "amazonses_verification_record" {
+  #count = var.enabled && var.verify_domain ? 1 : 0
 
-  zone_id = var.zone_id
+  #zone_id = var.zone_id
+  #name    = "_amazonses.${var.domain}"
+  #type    = "TXT"
+  #ttl     = "600"
+  #records = [join("", aws_ses_domain_identity.ses_domain.*.verification_token)]
+#}
+  
+resource "cloudflare_record" "amazonses_verification_record" {
+  count = var.enabled && var.verify_domain ? 1 : 0
+  
+  zone_id = var.cloudflare_zone_id
   name    = "_amazonses.${var.domain}"
+  value   = [join("", aws_ses_domain_identity.ses_domain.*.verification_token)]
   type    = "TXT"
-  ttl     = "600"
-  records = [join("", aws_ses_domain_identity.ses_domain.*.verification_token)]
 }
 
 resource "aws_ses_domain_dkim" "ses_domain_dkim" {
@@ -36,17 +45,25 @@ resource "aws_ses_domain_dkim" "ses_domain_dkim" {
   domain = join("", aws_ses_domain_identity.ses_domain.*.domain)
 }
 
-resource "aws_route53_record" "amazonses_dkim_record" {
+#resource "aws_route53_record" "amazonses_dkim_record" {
+  #count = var.enabled && var.verify_dkim ? 3 : 0
+
+  #zone_id = var.zone_id
+  #name    = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}._domainkey.${var.domain}"
+  #type    = "CNAME"
+  #ttl     = "600"
+  #records = ["${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"]
+#}
+
+resource "cloudflare_record" "amazonses_dkim_record" {
   count = var.enabled && var.verify_dkim ? 3 : 0
 
-  zone_id = var.zone_id
+  zone_id = var.cloudflare_zone_id
   name    = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}._domainkey.${var.domain}"
   type    = "CNAME"
-  ttl     = "600"
   records = ["${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"]
 }
-
-
+  
 /*
 Create user with permissions to send emails from SES domain
 */

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "dnsimple_record" "amazonses_verification_record" {
   count = var.enabled && var.verify_dnsimple_domain ? 1 : 0
   
   domain  = var.domain
-  name    = "_amazonses"
+  name    = trim(_amazonses, ".${var.domain}.")
   value   = aws_ses_domain_identity.ses_domain.0.verification_token
   type    = "TXT"
   ttl     = "60"

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "cloudflare_record" "amazonses_dkim_record" {
   name = format(
     "%s._domainkey.%s",
     element(aws_ses_domain_dkim.main.dkim_tokens, count.index),
-    var.domain_name,
+    var.domain,
   )
   type    = "CNAME"
   ttl     = "600"

--- a/main.tf
+++ b/main.tf
@@ -20,18 +20,18 @@ resource "aws_ses_domain_identity" "ses_domain" {
   domain = var.domain
 }
 
-#resource "aws_route53_record" "amazonses_verification_record" {
-  #count = var.enabled && var.verify_domain ? 1 : 0
+resource "aws_route53_record" "amazonses_verification_record" {
+  count = var.enabled && var.verify_route53_domain ? 1 : 0
 
-  #zone_id = var.zone_id
-  #name    = "_amazonses.${var.domain}"
-  #type    = "TXT"
-  #ttl     = "600"
-  #records = [join("", aws_ses_domain_identity.ses_domain.*.verification_token)]
-#}
+  zone_id = var.zone_id
+  name    = "_amazonses.${var.domain}"
+  type    = "TXT"
+  ttl     = "600"
+  records = [join("", aws_ses_domain_identity.ses_domain.*.verification_token)]
+}
   
 resource "cloudflare_record" "amazonses_verification_record" {
-  count = var.enabled && var.verify_domain ? 1 : 0
+  count = var.enabled && var.verify_cloudflare_domain ? 1 : 0
   
   zone_id = var.zone_id
   name    = "_amazonses.${var.domain}"
@@ -46,18 +46,18 @@ resource "aws_ses_domain_dkim" "ses_domain_dkim" {
   domain = join("", aws_ses_domain_identity.ses_domain.*.domain)
 }
 
-#resource "aws_route53_record" "amazonses_dkim_record" {
-  #count = var.enabled && var.verify_dkim ? 3 : 0
+resource "aws_route53_record" "amazonses_dkim_record" {
+  count = var.enabled && var.verify_route53_dkim ? 3 : 0
 
-  #zone_id = var.zone_id
-  #name    = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}._domainkey.${var.domain}"
-  #type    = "CNAME"
-  #ttl     = "600"
-  #records = ["${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"]
-#}
+  zone_id = var.zone_id
+  name    = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}._domainkey.${var.domain}"
+  type    = "CNAME"
+  ttl     = "600"
+  records = ["${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"]
+}
 
 resource "cloudflare_record" "amazonses_dkim_record" {
-  count = var.enabled && var.verify_dkim ? 3 : 0
+  count = var.enabled && var.verify_cloudflare_dkim ? 3 : 0
 
   zone_id = var.zone_id
   name = format(

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "label" {
 }
 
 /*
-Create SES domain identity and verify it with Route 53 or Cloudflare DNS records
+Create SES domain identity and verify it with Route 53 DNSimple or Cloudflare DNS records
 */
 
 resource "aws_ses_domain_identity" "ses_domain" {

--- a/main.tf
+++ b/main.tf
@@ -87,7 +87,6 @@ resource "dnsimple_record" "amazonses_dkim_record" {
   name = format(
     "%s._domainkey.%s",
     element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index),
-    var.domain,
   )
   type    = "CNAME"
   ttl     = "60"

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "cloudflare_record" "amazonses_verification_record" {
   
   zone_id = var.zone_id
   name    = "_amazonses.${var.domain}"
-  value   = aws_ses_domain_identity.ses_domain.*.verification_token
+  value   = aws_ses_domain_identity.ses_domain.0.verification_token
   type    = "TXT"
   ttl     = "600"
 }

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ resource "aws_route53_record" "amazonses_verification_record" {
   zone_id = var.zone_id
   name    = "_amazonses.${var.domain}"
   type    = "TXT"
-  ttl     = "600"
+  ttl     = "60"
   records = [join("", aws_ses_domain_identity.ses_domain.*.verification_token)]
 }
   
@@ -37,17 +37,17 @@ resource "cloudflare_record" "amazonses_verification_record" {
   name    = "_amazonses.${var.domain}"
   value   = aws_ses_domain_identity.ses_domain.0.verification_token
   type    = "TXT"
-  ttl     = "600"
+  ttl     = "60"
 }
   
 resource "dnsimple_record" "amazonses_verification_record" {
   count = var.enabled && var.verify_dnsimple_domain ? 1 : 0
   
   domain  = var.domain
-  name    = "_amazonses.${var.domain}"
+  name    = "_amazonses."
   value   = aws_ses_domain_identity.ses_domain.0.verification_token
   type    = "TXT"
-  ttl     = "600"
+  ttl     = "60"
 }
 
 resource "aws_ses_domain_dkim" "ses_domain_dkim" {
@@ -62,7 +62,7 @@ resource "aws_route53_record" "amazonses_dkim_record" {
   zone_id = var.zone_id
   name    = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}._domainkey.${var.domain}"
   type    = "CNAME"
-  ttl     = "600"
+  ttl     = "60"
   records = ["${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"]
 }
 
@@ -76,7 +76,7 @@ resource "cloudflare_record" "amazonses_dkim_record" {
     var.domain,
   )
   type    = "CNAME"
-  ttl     = "600"
+  ttl     = "60"
   value   = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"
 }
   
@@ -90,7 +90,7 @@ resource "dnsimple_record" "amazonses_dkim_record" {
     var.domain,
   )
   type    = "CNAME"
-  ttl     = "600"
+  ttl     = "60"
   value   = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ resource "cloudflare_record" "amazonses_dkim_record" {
   )
   type    = "CNAME"
   ttl     = "600"
-  value   = "${element(aws_ses_domain_dkim.ses_domain_dkim.dkim_tokens, count.index)}.dkim.amazonses.com"
+  value   = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"
 }
 
 /*

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ module "label" {
 }
 
 /*
-Create SES domain identity and verify it with Route 53 DNSimple or Cloudflare DNS records
+Create SES domain identity and verify it with Route 53, DNSimple or Cloudflare DNS records
 */
 
 resource "aws_ses_domain_identity" "ses_domain" {

--- a/main.tf
+++ b/main.tf
@@ -85,8 +85,9 @@ resource "dnsimple_record" "amazonses_dkim_record" {
 
   domain = var.domain
   name = format(
-    "%s._domainkey.",
-    element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index), var.domain,
+    "%s._domainkey.%s",
+    element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index), 
+    var.domain,
   )
   type    = "CNAME"
   ttl     = "60"

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "cloudflare_record" "amazonses_dkim_record" {
   zone_id = var.zone_id
   name = format(
     "%s._domainkey.%s",
-    element(aws_ses_domain_dkim.ses_domain_dkim.dkim_tokens, count.index),
+    element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index),
     var.domain,
   )
   type    = "CNAME"

--- a/main.tf
+++ b/main.tf
@@ -85,8 +85,8 @@ resource "dnsimple_record" "amazonses_dkim_record" {
 
   domain = var.domain
   name = format(
-    "%s._domainkey.%s",
-    element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index),
+    "%s._domainkey.",
+    element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index), var.domain,
   )
   type    = "CNAME"
   ttl     = "60"

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ resource "cloudflare_record" "amazonses_verification_record" {
   name    = "_amazonses.${var.domain}"
   value   = [join("", aws_ses_domain_identity.ses_domain.*.verification_token)]
   type    = "TXT"
+  ttl     = "600"
 }
 
 resource "aws_ses_domain_dkim" "ses_domain_dkim" {
@@ -61,6 +62,7 @@ resource "cloudflare_record" "amazonses_dkim_record" {
   zone_id = var.zone_id
   name    = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}._domainkey.${var.domain}"
   type    = "CNAME"
+  ttl     = "600"
   records = ["${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"]
 }
   

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "dnsimple_record" "amazonses_verification_record" {
   count = var.enabled && var.verify_dnsimple_domain ? 1 : 0
   
   domain  = var.domain
-  name    = "_amazonses."
+  name    = "_amazonses.${var.domain}"
   value   = aws_ses_domain_identity.ses_domain.0.verification_token
   type    = "TXT"
   ttl     = "60"

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "cloudflare_record" "amazonses_verification_record" {
   
   zone_id = var.zone_id
   name    = "_amazonses.${var.domain}"
-  value   = aws_ses_domain_identity.ses_domain.verification_token
+  value   = aws_ses_domain_identity.ses_domain.*.verification_token
   type    = "TXT"
   ttl     = "600"
 }

--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ resource "dnsimple_record" "amazonses_verification_record" {
   count = var.enabled && var.verify_dnsimple_domain ? 1 : 0
   
   domain  = var.domain
-  name    = trim(_amazonses, ".${var.domain}.")
+  name    = "_amazonses"
   value   = aws_ses_domain_identity.ses_domain.0.verification_token
   type    = "TXT"
   ttl     = "60"

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "cloudflare_record" "amazonses_dkim_record" {
   zone_id = var.zone_id
   name = format(
     "%s._domainkey.%s",
-    element(aws_ses_domain_dkim.main.dkim_tokens, count.index),
+    element(aws_ses_domain_dkim.ses_domain_dkim.dkim_tokens, count.index),
     var.domain,
   )
   type    = "CNAME"

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "cloudflare_record" "amazonses_dkim_record" {
   name    = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}._domainkey.${var.domain}"
   type    = "CNAME"
   ttl     = "600"
-  records = ["${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"]
+  value   = ["${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"]
 }
   
 /*

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "cloudflare_record" "amazonses_verification_record" {
   
   zone_id = var.zone_id
   name    = "_amazonses.${var.domain}"
-  value   = [join("", aws_ses_domain_identity.ses_domain.*.verification_token)]
+  value   = aws_ses_domain_identity.ses_domain.verification_token
   type    = "TXT"
   ttl     = "600"
 }
@@ -60,12 +60,16 @@ resource "cloudflare_record" "amazonses_dkim_record" {
   count = var.enabled && var.verify_dkim ? 3 : 0
 
   zone_id = var.zone_id
-  name    = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}._domainkey.${var.domain}"
+  name = format(
+    "%s._domainkey.%s",
+    element(aws_ses_domain_dkim.main.dkim_tokens, count.index),
+    var.domain_name,
+  )
   type    = "CNAME"
   ttl     = "600"
-  value   = ["${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"]
+  value   = "${element(aws_ses_domain_dkim.ses_domain_dkim.dkim_tokens, count.index)}.dkim.amazonses.com"
 }
-  
+
 /*
 Create user with permissions to send emails from SES domain
 */

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "aws_ses_domain_identity" "ses_domain" {
 resource "cloudflare_record" "amazonses_verification_record" {
   count = var.enabled && var.verify_domain ? 1 : 0
   
-  zone_id = var.cloudflare_zone_id
+  zone_id = var.zone_id
   name    = "_amazonses.${var.domain}"
   value   = [join("", aws_ses_domain_identity.ses_domain.*.verification_token)]
   type    = "TXT"
@@ -58,7 +58,7 @@ resource "aws_ses_domain_dkim" "ses_domain_dkim" {
 resource "cloudflare_record" "amazonses_dkim_record" {
   count = var.enabled && var.verify_dkim ? 3 : 0
 
-  zone_id = var.cloudflare_zone_id
+  zone_id = var.zone_id
   name    = "${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}._domainkey.${var.domain}"
   type    = "CNAME"
   records = ["${element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index)}.dkim.amazonses.com"]

--- a/main.tf
+++ b/main.tf
@@ -85,9 +85,8 @@ resource "dnsimple_record" "amazonses_dkim_record" {
 
   domain = var.domain
   name = format(
-    "%s._domainkey.%s",
+    "%s._domainkey",
     element(aws_ses_domain_dkim.ses_domain_dkim.0.dkim_tokens, count.index), 
-    var.domain,
   )
   type    = "CNAME"
   ttl     = "60"

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,12 @@ variable "verify_cloudflare_domain" {
   default     = false
 }
 
+variable "verify_dnsimple_domain" {
+  type        = bool
+  description = "If provided the module will create DNSimple DNS records used for domain verification."
+  default     = false
+}
+
 variable "verify_route53_dkim" {
   type        = bool
   description = "If provided the module will create Route53 DNS records used for DKIM verification."
@@ -71,6 +77,12 @@ variable "verify_route53_dkim" {
 variable "verify_cloudflare_dkim" {
   type        = bool
   description = "If provided the module will create Cloudflare DNS records used for DKIM verification."
+  default     = false
+}
+
+variable "verify_dnsimple_dkim" {
+  type        = bool
+  description = "If provided the module will create DNSimple DNS records used for DKIM verification."
   default     = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -50,15 +50,27 @@ variable "zone_id" {
   default     = ""
 }
 
-variable "verify_domain" {
+variable "verify_route53_domain" {
   type        = bool
   description = "If provided the module will create Route53 DNS records used for domain verification."
   default     = false
 }
 
-variable "verify_dkim" {
+variable "verify_cloudflare_domain" {
+  type        = bool
+  description = "If provided the module will create Cloudflare DNS records used for domain verification."
+  default     = false
+}
+
+variable "verify_route53_dkim" {
   type        = bool
   description = "If provided the module will create Route53 DNS records used for DKIM verification."
+  default     = false
+}
+
+variable "verify_cloudflare_dkim" {
+  type        = bool
+  description = "If provided the module will create Cloudflare DNS records used for DKIM verification."
   default     = false
 }
 


### PR DESCRIPTION
## what
* You can now use Route 53 to activate the DNS validation or Cloudflare
* Setting the verify_route53_domain to true will use Route53
* Setting the verify_cloudflare_domain to true will use Cloudflare
* The same works for verify_route53_dkim and verify_cloudflare_dkim

## why
* Not everyone uses Route53
* Allow the user to choose between 2 major providers

## references
* None

