### PR TITLE
Enable less restrictive policy for IAM user

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Available targets:
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | iam\_permissions | Specifies permissions for the IAM user. | `list(string)` | <pre>[<br>  "ses:SendRawEmail"<br>]</pre> | no |
+| iam\_resources\_override | Allows override of resources to which are granted 'iam\_permissions' for the IAM user. | `list(string)` | `[]` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -26,6 +26,7 @@
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | iam\_permissions | Specifies permissions for the IAM user. | `list(string)` | <pre>[<br>  "ses:SendRawEmail"<br>]</pre> | no |
+| iam\_resources\_override | Allows override of resources to which are granted 'iam\_permissions' for the IAM user. | `list(string)` | `[]` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "ses_user_policy" {
 
   statement {
     actions   = var.iam_permissions
-    resources = [join("", aws_ses_domain_identity.ses_domain.*.arn)]
+    resources = length(var.iam_resources_override) > 0 ? var.iam_resources_override : [join("", aws_ses_domain_identity.ses_domain.*.arn)]
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -26,3 +26,9 @@ variable "iam_permissions" {
   description = "Specifies permissions for the IAM user."
   default     = ["ses:SendRawEmail"]
 }
+
+variable "iam_resources_override" {
+  type        = list(string)
+  description = "Allows override of resources to which are granted 'iam_permissions' for the IAM user."
+  default     = []
+}


### PR DESCRIPTION
## what
* Add new input variable `iam_resources_override` which can be set to something like `["*"]` to override the module default resource
* When `iam_resources_override` is not set, the existing module functionality is preserved.

## why
* We found the existing policy too restrictive and could not get it to work without modifying the code to
pass in at least the ARN of a registered email address, or more broadly `["*"]` instead.

## references
[Enable less restrictive policy #19](https://github.com/cloudposse/terraform-aws-ses/issues/19)

