### PR TITLE
fix: fixes 0.14 compat via ses_user version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ Create user with permissions to send emails from SES domain
 */
 module "ses_user" {
   source  = "cloudposse/iam-system-user/aws"
-  version = "0.16.0"
+  version = "0.17.0"
 
   context = module.this.context
 }


### PR DESCRIPTION
## what
* Upgrades the terraform-aws-iam-system-user module to 0.17.0

## why
* Fixes support for Terraform v0.14 in this module. 

## references
* See stack trace from @vdmkenny in #22 here: https://github.com/cloudposse/terraform-aws-ses/pull/22#issuecomment-760964529

