### PR TITLE
Calculate IAM Group name from a context by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Available targets:
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_ses_group_enabled"></a> [ses\_group\_enabled](#input\_ses\_group\_enabled) | Creates a group with permission to send emails from SES domain | `bool` | `true` | no |
-| <a name="input_ses_group_name"></a> [ses\_group\_name](#input\_ses\_group\_name) | The name of the group to create | `string` | `"SESSenders"` | no |
+| <a name="input_ses_group_name"></a> [ses\_group\_name](#input\_ses\_group\_name) | The name of the IAM group to create. If empty the module will calculate name from a context (recommended). | `string` | `""` | no |
 | <a name="input_ses_group_path"></a> [ses\_group\_path](#input\_ses\_group\_path) | The IAM Path of the group to create | `string` | `"/"` | no |
 | <a name="input_ses_user_enabled"></a> [ses\_user\_enabled](#input\_ses\_user\_enabled) | Creates user with permission to send emails from SES domain | `bool` | `true` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -53,7 +53,7 @@
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_ses_group_enabled"></a> [ses\_group\_enabled](#input\_ses\_group\_enabled) | Creates a group with permission to send emails from SES domain | `bool` | `true` | no |
-| <a name="input_ses_group_name"></a> [ses\_group\_name](#input\_ses\_group\_name) | The name of the group to create | `string` | `"SESSenders"` | no |
+| <a name="input_ses_group_name"></a> [ses\_group\_name](#input\_ses\_group\_name) | The name of the IAM group to create. If empty the module will calculate name from a context (recommended). | `string` | `""` | no |
 | <a name="input_ses_group_path"></a> [ses\_group\_path](#input\_ses\_group\_path) | The IAM Path of the group to create | `string` | `"/"` | no |
 | <a name="input_ses_user_enabled"></a> [ses\_user\_enabled](#input\_ses\_user\_enabled) | Creates user with permission to send emails from SES domain | `bool` | `true` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,8 @@ resource "aws_route53_record" "amazonses_dkim_record" {
 locals {
   create_group_enabled = module.this.enabled && var.ses_group_enabled
   create_user_enabled  = module.this.enabled && var.ses_user_enabled
+
+  ses_group_name = coalesce(var.ses_group_name, module.this.id)
 }
 
 data "aws_iam_policy_document" "ses_policy" {
@@ -55,7 +57,7 @@ data "aws_iam_policy_document" "ses_policy" {
 resource "aws_iam_group" "ses_users" {
   count = local.create_group_enabled ? 1 : 0
 
-  name = var.ses_group_name
+  name = local.ses_group_name
   path = var.ses_group_path
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,8 +35,8 @@ variable "ses_group_enabled" {
 
 variable "ses_group_name" {
   type        = string
-  description = "The name of the group to create"
-  default     = "SESSenders"
+  description = "The name of the IAM group to create. If empty the module will calculate name from a context (recommended)."
+  default     = ""
 }
 
 variable "ses_group_path" {


### PR DESCRIPTION
## what
* Calculate IAM Group name from a context by default

## why
* Hardcoded name causes collision on multi-region deployments

## references
NOTE: this is a breaking change, I checked, the IAM group name can be updated in place, user binding too, but policy:
```
module.ses.aws_iam_group_policy.ses_group_policy[0] must be replaced
```
When you deploy this in a production environment it will cause a short IAM policy loss, which might cause some ongoing operations to fail. To avoid this blink, explicitly override the name to the previous value:
```
ses_group_name = "SESSenders"
```