### PR TITLE
Update Tests Tofu and TF in parallel

### DIFF
--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"fmt"
 	"math/rand"
 	"os/exec"
 	"strings"
@@ -65,5 +66,5 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	userName := terraform.Output(t, terraformOptions, "user_name")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "eg-test-ses", userName)
+	assert.Equal(t, fmt.Sprintf("eg-test-ses-%s", platform), userName)
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	"math/rand"
+	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +12,20 @@ import (
 )
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz1234567890")
+
+func detectPlatform() string {
+	cmd := exec.Command("terraform", "--version")
+	out, _ := cmd.CombinedOutput()
+	platform := ""
+	if strings.Contains(string(out), "Terraform") {
+		platform = "tf"
+	} else if strings.Contains(string(out), "OpenTofu") {
+		platform = "tofu"
+	} else {
+		platform = "unknown"
+	}
+	return platform
+}
 
 func RandStringRunes(n int) string {
 	rand.Seed(time.Now().UnixNano())
@@ -26,7 +42,8 @@ func TestExamplesComplete(t *testing.T) {
 	// t.Parallel()
 
 	testName := "ses-test-" + RandStringRunes(10)
-
+	platform := detectPlatform()
+	attributes := []string{platform}
 	terraformOptions := &terraform.Options{
 		// The path to where our Terraform code is located
 		TerraformDir: "../../examples/complete",
@@ -34,7 +51,8 @@ func TestExamplesComplete(t *testing.T) {
 		// Variables to pass to our Terraform code using -var-file options
 		VarFiles: []string{"fixtures.us-east-2.tfvars"},
 		Vars: map[string]interface{}{
-			"name": testName,
+			"name":       testName,
+			"attributes": attributes,
 		},
 	}
 


### PR DESCRIPTION
## what

Updates tests to add an attribute for platform which is whether it is `tf` or `tofu`

## why

 Tests that don't differentiate create (or try to) the same resources resulting in failed tests from resource collision

## references
#99 